### PR TITLE
Fix the expected fails in t_getrusage.

### DIFF
--- a/README
+++ b/README
@@ -4,16 +4,17 @@ Reimplement ATF with many hacks to adjust the tests as little as possible.
 
 Tests passing without source file adjustments:
 t_access	t_getpid	t_kill		t_msgsnd	t_sigaction
-t_bind		t_getrusage	t_link		t_msync		t_socketpair
-t_getgroups	t_getsid	t_listen	t_pipe		t_truncate
-t_getitimer	t_getsockname	t_mkdir		t_sendrecv	t_umask
-t_getlogin	t_gettimeofday	t_msgctl	t_setuid	t_write
+t_bind		t_link		t_msync		t_socketpair	t_getgroups
+t_getsid	t_listen	t_pipe		t_truncate	t_getitimer
+t_getsockname	t_mkdir		t_sendrecv	t_umask		t_getlogin
+t_gettimeofday	t_msgctl	t_setuid	t_write
 
 Tests passing after adjustments:
 t_chroot	- fchroot is not implemented
 t_clock_gettime	- requires sysctlbyname
 t_dup		- OpenBSD dup3 is similar Linux dup3
 t_fsync		- replace mkstemp
+t_getrusage	- no expected fail, PR kern/30115 is NetBSD, work more
 t_mknod 	- remove tests for unsupported file types
 t_msgget	- remove msgget_limit test
 t_poll 		- remove pollts tests

--- a/t_getrusage.c
+++ b/t_getrusage.c
@@ -208,7 +208,6 @@ ATF_TC_BODY(getrusage_utime_back, tc)
 	/*
 	 * Test that two consecutive calls are sane.
 	 */
-	atf_tc_expect_fail("PR kern/30115");
 
 	for (i = 0; i < maxiter; i++) {
 
@@ -226,8 +225,6 @@ ATF_TC_BODY(getrusage_utime_back, tc)
 		if (timercmp(&ru2.ru_utime, &ru1.ru_utime, <) != 0)
 			atf_tc_fail("user time went backwards");
 	}
-
-	atf_tc_fail("anticipated error did not occur");
 }
 
 ATF_TC(getrusage_utime_zero);
@@ -244,24 +241,18 @@ ATF_TC_BODY(getrusage_utime_zero, tc)
 	/*
 	 * Test that getrusage(2) does not return
 	 * zero user time for the calling process.
-	 *
-	 * See also (duplicate) PR port-amd64/41734.
 	 */
-	atf_tc_expect_fail("PR kern/30115");
 
 	for (i = 0; i < maxiter; i++) {
-
 		work();
-
-		(void)memset(&ru, 0, sizeof(struct rusage));
-
-		ATF_REQUIRE(getrusage(RUSAGE_SELF, &ru) == 0);
-
-		if (ru.ru_utime.tv_sec == 0 && ru.ru_utime.tv_usec == 0)
-			atf_tc_fail("zero user time from getrusage(2)");
 	}
 
-	atf_tc_fail("anticipated error did not occur");
+	(void)memset(&ru, 0, sizeof(struct rusage));
+
+	ATF_REQUIRE(getrusage(RUSAGE_SELF, &ru) == 0);
+
+	if (ru.ru_utime.tv_sec == 0 && ru.ru_utime.tv_usec == 0)
+		atf_tc_fail("zero user time from getrusage(2)");
 }
 
 ATF_TP_ADD_TCS(tp)


### PR DESCRIPTION
getrusage_utime_back just works in OpenBSD
getrusage_utime_zero work has to run for hz seconds, loop test makes no sense