### PR TITLE
Allow more space in getgroups(2) test.

### DIFF
--- a/t_getgroups.c
+++ b/t_getgroups.c
@@ -56,7 +56,7 @@ ATF_TC_BODY(getgroups_err, tc)
 
 	errno = 0;
 
-	ATF_REQUIRE(getgroups(10, (gid_t *)-1) == -1);
+	ATF_REQUIRE(getgroups(NGROUPS_MAX, (gid_t *)-1) == -1);
 	ATF_REQUIRE(errno == EFAULT);
 
 	errno = 0;


### PR DESCRIPTION
Users with many groups need more space to get correct errno EFAULT.
Use NGROUPS_MAX as this is the defined maximum.